### PR TITLE
Auto-leave widget, bank UI overhaul, and granular notifications

### DIFF
--- a/AutoLeaveToggle.lua
+++ b/AutoLeaveToggle.lua
@@ -1,0 +1,125 @@
+TelVarSaver = TelVarSaver or {}
+local TVS = TelVarSaver
+
+TVS.autoLeaveToggleMoved = false
+
+function TVS.UpdateAutoLeaveTogglePosition()
+	local control = TVSAutoLeaveToggle
+	if control == nil then return end
+	control:ClearAnchors()
+	control:SetAnchor(TOPRIGHT, GuiRoot, TOPRIGHT, TVS.SV.AutoLeaveToggleX, TVS.SV.AutoLeaveToggleY)
+	control:SetMovable(TVS.SV.AutoLeaveToggleDragable)
+end
+
+function TVS.SaveAutoLeaveTogglePosition()
+	local control = TVSAutoLeaveToggle
+	if control == nil then return end
+	TVS.SV.AutoLeaveToggleX = control:GetRight() - GuiRoot:GetRight()
+	TVS.SV.AutoLeaveToggleY = control:GetTop() - GuiRoot:GetTop()
+end
+
+-- The widget is parented to the gameplay scenes via a HUD scene fragment (the same
+-- approach Combat Metrics uses). The engine then shows/hides it with the scene -
+-- no per-event work - so it disappears in menus/inventory/map and returns in play.
+TVS.AUTO_LEAVE_SCENES = { "hud", "hudui", "siegeBar" }
+
+function TVS.RefreshAutoLeaveToggleVisibility()
+	local control = TVSAutoLeaveToggle
+	if control == nil or TVS.autoLeaveToggleFragment == nil or SCENE_MANAGER == nil then return end
+
+	local available = (TVS.SV.AutoLeaveToggleShow == true) and (IsInImperialCity() == true)
+
+	if available then
+		for _, sceneName in ipairs(TVS.AUTO_LEAVE_SCENES) do
+			SCENE_MANAGER:GetScene(sceneName):AddFragment(TVS.autoLeaveToggleFragment)
+		end
+		-- Match the current scene immediately (AddFragment only acts on transitions).
+		local currentScene = SCENE_MANAGER.currentScene and SCENE_MANAGER.currentScene.name or ""
+		local shownForScene = false
+		for _, sceneName in ipairs(TVS.AUTO_LEAVE_SCENES) do
+			if currentScene == sceneName then shownForScene = true end
+		end
+		control:SetHidden(not shownForScene)
+	else
+		for _, sceneName in ipairs(TVS.AUTO_LEAVE_SCENES) do
+			SCENE_MANAGER:GetScene(sceneName):RemoveFragment(TVS.autoLeaveToggleFragment)
+		end
+		control:SetHidden(true)
+	end
+end
+
+function TVS.UpdateAutoLeaveToggleVisual()
+	if TVSAutoLeaveToggleStatus == nil then return end
+	local cap = tostring(TVS.SV.TelvarCap)
+	local carried = GetCarriedCurrencyAmount(CURT_TELVAR_STONES)
+	local queueLimit = GetTelVarQueueThreshold()
+
+	if carried > queueLimit then
+		TVSAutoLeaveToggleStatus:SetText("|cffff00" .. cap .. "|r")
+		TVSAutoLeaveToggleIcon:SetColor(1, 1, 1, 1)
+	elseif TVS.SV.AutoQueueOut == true then
+		TVSAutoLeaveToggleStatus:SetText("|c00ff00" .. cap .. "|r")
+		TVSAutoLeaveToggleIcon:SetColor(1, 1, 1, 1)
+	else
+		TVSAutoLeaveToggleStatus:SetText("|cff4040" .. cap .. "|r")
+		TVSAutoLeaveToggleIcon:SetColor(1, 1, 1, 0.35)
+	end
+
+	if TVS.SV.AutoQueueOut == true then
+		TVSAutoLeaveToggleBG:SetEdgeColor(0, 1, 0, 1)
+	else
+		TVSAutoLeaveToggleBG:SetEdgeColor(1, 0.25, 0.25, 1)
+	end
+end
+
+function TVS.ToggleAutoLeave()
+	TVS.SV.AutoQueueOut = not TVS.SV.AutoQueueOut
+	TVS.UpdateAutoLeaveToggleVisual()
+	if TVS.SV.AutoQueueOut == true then
+		TVS.dtvs("Auto leave when telvar limit reached: |c00ff00ON|r", "notifyAutoLeave")
+	else
+		TVS.dtvs("Auto leave when telvar limit reached: |cff4040OFF|r", "notifyAutoLeave")
+	end
+end
+
+function TVS.SetupAutoLeaveToggle()
+	if TVS.autoLeaveToggleFragment == nil then
+		TVS.autoLeaveToggleFragment = ZO_HUDFadeSceneFragment:New(TVSAutoLeaveToggle)
+	end
+	TVS.UpdateAutoLeaveTogglePosition()
+	TVS.UpdateAutoLeaveToggleVisual()
+	TVS.RefreshAutoLeaveToggleVisibility()
+end
+
+function TVS.OnAutoLeaveToggleMoveStart() TVS.autoLeaveToggleMoved = true end
+
+function TVS.OnAutoLeaveToggleMoveStop() TVS.SaveAutoLeaveTogglePosition() end
+
+-- Open the addon settings panel (right-click shortcut).
+function TVS.OpenSettings()
+	if LibAddonMenu2 ~= nil and TVS.settingsPanel ~= nil then LibAddonMenu2:OpenToPanel(TVS.settingsPanel) end
+end
+
+-- Left click toggles, right click opens settings - but not at the end of a drag.
+function TVS.OnAutoLeaveToggleMouseUp(button, upInside)
+	if upInside == false then return end
+	if TVS.autoLeaveToggleMoved == true then
+		TVS.autoLeaveToggleMoved = false
+		return
+	end
+	if button == MOUSE_BUTTON_INDEX_LEFT then
+		TVS.ToggleAutoLeave()
+	elseif button == MOUSE_BUTTON_INDEX_RIGHT then
+		TVS.OpenSettings()
+	end
+end
+
+function TVS.OnAutoLeaveToggleEnter()
+	InitializeTooltip(InformationTooltip, TVSAutoLeaveToggle, BOTTOM, 0, -5)
+	SetTooltipText(InformationTooltip, "Tel Var Saver")
+	SetTooltipText(InformationTooltip, "Left click to toggle 'Auto leave when telvar limit reached'.")
+	SetTooltipText(InformationTooltip, "Right click to open settings.")
+	SetTooltipText(InformationTooltip, "Unlock drag to move in settings. Lock or hide it in the addon settings.")
+end
+
+function TVS.OnAutoLeaveToggleExit() ClearTooltip(InformationTooltip) end

--- a/BankScene.lua
+++ b/BankScene.lua
@@ -5,6 +5,7 @@ function TVS.HideUi() TVSView:SetHidden(true) end
 
 function TVS.ShowUi()
 	TVS.UpdateText()
+	TVS.UpdateBankControls()
 	TVSView:SetHidden(false)
 end
 
@@ -16,25 +17,65 @@ end
 function TVS.UpdateText()
 	local currentTelvarOnChar = GetCarriedCurrencyAmount(CURT_TELVAR_STONES)
 	local currentTelvarStonesInBank = GetBankedCurrencyAmount(CURT_TELVAR_STONES)
-	TVSViewCurrentTextValue:SetText(TVS.TELVAR_CHAT_ICON .. ": |c8080ff" .. tostring(currentTelvarOnChar) .. "|r")
-	TVSViewBankTextValue:SetText(TVS.TELVAR_CHAT_ICON .. ": |c8080ff" .. tostring(currentTelvarStonesInBank) .. "|r")
+	TVSViewCurrentTextValue:SetText(TVS.TELVAR_CHAT_ICON .. " |c8080ff" .. ZO_CommaDelimitNumber(currentTelvarOnChar) .. "|r")
+	TVSViewBankTextValue:SetText(TVS.TELVAR_CHAT_ICON .. " |c8080ff" .. ZO_CommaDelimitNumber(currentTelvarStonesInBank) .. "|r")
 	TVSViewButtonDepo1k:SetAlpha(1)
 	TVSViewButtonDepo10k:SetAlpha(1)
-	-- Checking if the player has enough telvar to actually use the buttons.
-	if
-		(currentTelvarStonesInBank < 10000)
-		and (currentTelvarOnChar - currentTelvarOnChar < 10000)
-		and (currentTelvarOnChar < 10000)
-	then
+	-- Dim a button when the player can't reach that amount (not enough telvar
+	-- carried, and not enough in the bank to withdraw up to it).
+	if (currentTelvarStonesInBank < 10000) and (currentTelvarOnChar < 10000) then
 		TVSViewButtonDepo10k:SetAlpha(0.5)
 	end
-	if
-		(currentTelvarStonesInBank < 1000)
-		and (currentTelvarOnChar - currentTelvarOnChar < 1000)
-		and (currentTelvarOnChar < 1000)
-	then
+	if (currentTelvarStonesInBank < 1000) and (currentTelvarOnChar < 1000) then
 		TVSViewButtonDepo1k:SetAlpha(0.5)
 	end
+end
+
+-- -------------------------------------------------------------------------------
+-- In-window auto manage controls (mirror the addon menu settings)
+-- -------------------------------------------------------------------------------
+
+-- One-time setup of the native checkbox toggles (label + click behavior).
+function TVS.SetupBankCheckButtons()
+	if TVSViewAutoDepoToggle == nil then return end
+
+	ZO_CheckButton_SetLabelText(TVSViewAutoDepoToggle, "Auto deposit telvar")
+	ZO_CheckButton_SetToggleFunction(TVSViewAutoDepoToggle, function(_, checked)
+		TVS.SV.AutoDepoTelvar = checked
+		TVS.UpdateBankControls()
+	end)
+
+	ZO_CheckButton_SetLabelText(TVSViewAutoWithdrawToggle, "Auto withdraw telvar")
+	ZO_CheckButton_SetToggleFunction(TVSViewAutoWithdrawToggle, function(_, checked)
+		TVS.SV.AutoWithdrawTelvar = checked
+		TVS.UpdateBankControls()
+	end)
+end
+
+-- Sync the checkbox states and the desired-amount editbox with the saved settings.
+function TVS.UpdateBankControls()
+	if TVSView == nil then return end
+
+	-- SetCheckState only updates the visual; it does not call the toggle function.
+	ZO_CheckButton_SetCheckState(TVSViewAutoDepoToggle, TVS.SV.AutoDepoTelvar)
+	ZO_CheckButton_SetCheckState(TVSViewAutoWithdrawToggle, TVS.SV.AutoWithdrawTelvar)
+
+	-- Keep the editbox in sync unless the user is currently typing in it.
+	if TVSViewDesiredBackdropEdit:HasFocus() == false then
+		TVSViewDesiredBackdropEdit:SetText(tostring(TVS.SV.DesiredTelvarAmount))
+	end
+end
+
+-- Validate and store the desired carried amount typed into the in-window editbox.
+function TVS.CommitDesiredEdit()
+	local amount = tonumber(TVSViewDesiredBackdropEdit:GetText())
+	if not amount then amount = TVS.SV.DesiredTelvarAmount end
+	if (amount < 0) or (amount > 10000) then
+		amount = TVS.SV.DesiredTelvarAmount
+		TVS.dtvs("Invalid amount. Must be between 0 and 10000", "notifyBank")
+	end
+	TVS.SV.DesiredTelvarAmount = amount
+	TVS.UpdateBankControls()
 end
 
 function TVS.SaveLocation()
@@ -45,7 +86,7 @@ end
 function TVS.UpdateAnchors()
 	TVSView:ClearAnchors()
 	TVSView:SetAnchor(TOPLEFT, GuiRoot, TOPLEFT, TVS.SV.locationx, TVS.SV.locationy)
-	TVSView:SetMovable(TVS.SV.dragable)
+	TVSView:SetMovable(TVS.SV.draggable)
 end
 
 function TVS.UpdateUi() TVS.UpdateAnchors() end

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # TelvarSaver
-ESO LUA addon 
+ESO Lua addon 
 The ultimate standalone IC telvar addon
-This addon adds 2 major life savers and multiple timer savers to IC.
+This addon adds 2 major life savers and multiple time savers to IC.
 
 1) Auto Queue out of IC when you reach a certain telvar amount
-2) Adds a keybind to queue out to drastically increase the speed you can leave IC. Without this addon, you have to open your alliance menu, scroll over to a campaign, and queue out, all while youre likely being attacked. This is a massive game changer, since with this addon you can basically hit your keybind and within 5-10ish seconds be out of IC safe and sound with your telvar.
+2) Adds a keybind to queue out to drastically increase the speed you can leave IC. Without this addon, you have to open your alliance menu, scroll over to a campaign, and queue out, all while you're likely being attacked. This is a massive game changer, since with this addon you can basically hit your keybind and within 5-10ish seconds be out of IC safe and sound with your telvar.
 3) Easily withdraw and deposit preset amounts of telvar from your bank (0,1k,10k) using the menu.
 4) Automatically deposit or withdraw telvar to reach a custom amount from your settings menu when opening the bank. Could be used to always deposit all your telvar or always withdraw 10k for the 4x bonus.
 5) Auto loot key fragments (now Imperial Fragments)

--- a/TelvarSaver.lua
+++ b/TelvarSaver.lua
@@ -2,10 +2,12 @@ TelVarSaver = TelVarSaver or {}
 local TVS = TelVarSaver
 
 TVS.name = "Telvar Saver"
-TVS.version = "1.7"
+TVS.version = "1.8"
 TVS.author = "Ehansonn"
 
 TVS.SavedVariablesName = "TVSVars"
+-- NOTE: This is the ZO_SavedVars version. Bumping it WIPES all saved settings,
+-- so it intentionally stays put; upgrades are handled by TVS.HandleMigration().
 TVS.SVVersion = "1.7"
 
 -- Known campaign IDs (reference-only for dev/debug):
@@ -28,7 +30,10 @@ TVS.defaults = {
 	AutoLootTelvar = false,
 	AutoLootKeyFrags = true,
 	notifications = true,
-	dragable = true,
+	notifyBank = false,
+	notifyAutoLeave = false,
+	notifyQueue = false,
+	draggable = true,
 	locationx = 275,
 	locationy = 150,
 	BankScene = true,
@@ -43,6 +48,10 @@ TVS.defaults = {
 	DisableKeybindInPVE = true,
 	SmartQueuePicker = false,
 	AllowCyrodiilCampaigns = false,
+	AutoLeaveToggleShow = false,
+	AutoLeaveToggleDragable = false,
+	AutoLeaveToggleX = -250,
+	AutoLeaveToggleY = 250,
 }
 
 -- Telvar Icon
@@ -105,12 +114,29 @@ function TVS.onLoad(eventCode, addonName)
 
 	-- Creating keybinds
 	ZO_CreateStringId("SI_BINDING_NAME_QUEUETVSCAMP", "Queue into your selected campaign")
+	ZO_CreateStringId("SI_BINDING_NAME_TVSTOGGLEAUTOLEAVE", "Toggle auto leave when telvar limit reached")
 	SLASH_COMMANDS["/tvs"] = TVS.queueCamp
 	SLASH_COMMANDS["/tvsdb"] = TVS.DebugStuff
 
 	-- Update Bank Scene UI
 	TVS.UpdateAnchors()
 	TVS.UpdateText()
+	TVS.SetupBankCheckButtons()
+	TVS.UpdateBankControls()
+
+	-- On-screen Auto-Leave toggle button (only visible while in Imperial City)
+	TVS.SetupAutoLeaveToggle()
+	EVENT_MANAGER:RegisterForEvent(
+		TVS.name .. "_AutoLeaveToggleVis",
+		EVENT_PLAYER_ACTIVATED,
+		TVS.RefreshAutoLeaveToggleVisibility
+	)
+	-- Refresh the button color as carried telvar crosses the queue limit
+	EVENT_MANAGER:RegisterForEvent(
+		TVS.name .. "_AutoLeaveToggleTelvar",
+		EVENT_TELVAR_STONE_UPDATE,
+		TVS.UpdateAutoLeaveToggleVisual
+	)
 
 	-- Auto loot imperial fragments
 	EVENT_MANAGER:RegisterForEvent(TVS.name, EVENT_LOOT_UPDATED, TVS.OnLootUpdated)
@@ -143,7 +169,7 @@ end
 -- Autoloot stuff
 -- -------------------------------------------------------------------------------
 
--- Checking if we looted a imperial fragments. Thanks smarter auto loot
+-- Checking if we looted imperial fragments. Thanks smarter auto loot
 function TVS.OnLootUpdated()
 	local name, interactType, actionName, owned = GetLootTargetInfo()
 	if IsInImperialCity() == false then return end
@@ -202,18 +228,18 @@ function TVS.DepositTelvar()
 	if (currentTelvarOnChar > TVS.SV.DesiredTelvarAmount) and (TVS.SV.AutoDepoTelvar == true) then
 		local amount = currentTelvarOnChar - TVS.SV.DesiredTelvarAmount
 		DepositCurrencyIntoBank(CURT_TELVAR_STONES, amount)
-		TVS.dtvs("auto deposited " .. "|c8080ff" .. tostring(amount) .. "|r " .. TVS.TELVAR_CHAT_ICON)
+		TVS.dtvs("auto deposited " .. "|c8080ff" .. tostring(amount) .. "|r " .. TVS.TELVAR_CHAT_ICON, "notifyBank")
 		return
 	end
 
 	if (currentTelvarOnChar < TVS.SV.DesiredTelvarAmount) and (TVS.SV.AutoWithdrawTelvar == true) then
 		local amount = TVS.SV.DesiredTelvarAmount - currentTelvarOnChar
 		if currentTelvarStonesInBank < amount then
-			TVS.dtvs("Auto withdraw failed")
+			TVS.dtvs("Auto withdraw failed", "notifyBank")
 			return
 		end
 		WithdrawCurrencyFromBank(CURT_TELVAR_STONES, amount)
-		TVS.dtvs("auto withdrew " .. "|c8080ff" .. tostring(amount) .. "|r " .. TVS.TELVAR_CHAT_ICON)
+		TVS.dtvs("auto withdrew " .. "|c8080ff" .. tostring(amount) .. "|r " .. TVS.TELVAR_CHAT_ICON, "notifyBank")
 		return
 	end
 end
@@ -226,7 +252,7 @@ function TVS.TelvarButton(value)
 	if currentTelvarOnChar > value then
 		local amount = currentTelvarOnChar - value
 		DepositCurrencyIntoBank(CURT_TELVAR_STONES, amount)
-		TVS.dtvs("deposited " .. "|c8080ff" .. tostring(amount) .. "|r " .. TVS.TELVAR_CHAT_ICON)
+		TVS.dtvs("deposited " .. "|c8080ff" .. tostring(amount) .. "|r " .. TVS.TELVAR_CHAT_ICON, "notifyBank")
 		return
 	end
 
@@ -234,12 +260,12 @@ function TVS.TelvarButton(value)
 		local amount = value - currentTelvarOnChar
 
 		if currentTelvarStonesInBank < amount then
-			TVS.dtvs("Not enough telvar to withdraw")
+			TVS.dtvs("Not enough telvar to withdraw", "notifyBank")
 			return
 		end
 		WithdrawCurrencyFromBank(CURT_TELVAR_STONES, amount)
 		TVS.UpdateText()
-		TVS.dtvs("withdrew " .. "|c8080ff" .. tostring(amount) .. "|r " .. TVS.TELVAR_CHAT_ICON)
+		TVS.dtvs("withdrew " .. "|c8080ff" .. tostring(amount) .. "|r " .. TVS.TELVAR_CHAT_ICON, "notifyBank")
 		return
 	end
 end
@@ -380,7 +406,7 @@ end
 function TVS.CanQueueForCampaign(campaignId)
 	if campaignId == nil then return false end
 	if DoesTelVarAmountPreventQueuing() == true then
-		TVS.dtvs("Cannot queue: Tel Var amount prevents queuing for [" .. tostring(GetCampaignName(campaignId)) .. "] with more than " .. tostring(GetTelVarQueueThreshold()) .. " " .. TVS.TELVAR_CHAT_ICON)
+		TVS.dtvs("Cannot queue: Tel Var amount prevents queuing for [" .. tostring(GetCampaignName(campaignId)) .. "] with more than " .. tostring(GetTelVarQueueThreshold()) .. " " .. TVS.TELVAR_CHAT_ICON, "notifyQueue")
 		return false
 	end
 	return true
@@ -405,7 +431,7 @@ function TVS.QueueForCampaignWithEstimate(campaignId, queueAsGroup)
 
 	local name = tostring(GetCampaignName(campaignId))
 	local waitPretty = TVS.GetCampaignQueueWaitPretty(campaignId)
-	TVS.dtvs(string.format("Queued for [%s] (estimated wait %s)", name, waitPretty))
+	TVS.dtvs(string.format("Queued for [%s] (estimated wait %s)", name, waitPretty), "notifyQueue")
 
 	QueueForCampaign(campaignId, queueAsGroup)
 
@@ -496,7 +522,7 @@ function TVS.AutoAccept(eventCode, id, isGroup, state)
 	local groupQueue = TVS.GetGroupQueue()
 
 	if state == CAMPAIGN_QUEUE_REQUEST_STATE_CONFIRMING then
-		TVS.dtvs("Entering campaign [" .. tostring(GetCampaignName(id)) .. "]")
+		TVS.dtvs("Entering campaign [" .. tostring(GetCampaignName(id)) .. "]", "notifyQueue")
 		ConfirmCampaignEntry(id, groupQueue, true)
 	end
 end
@@ -547,7 +573,7 @@ function TVS.AutoKickOfflinePlayers(campaignID)
 			local name = GetUnitName(unitTag)
 			GroupKick(unitTag)
 			count = count + 1
-			TVS.dtvs("Kicking " .. name)
+			TVS.dtvs("Kicking " .. name, "notifyQueue")
 		end
 	end
 
@@ -582,11 +608,22 @@ function TVS.HandleMigration()
 		TVS.SV.EscapeCamp = TVS.defaults.EscapeCamp
 	end
 
+	-- The "dragable" setting was renamed to "draggable"; carry over the old value.
+	if TVS.SV.dragable ~= nil then
+		TVS.SV.draggable = TVS.SV.dragable
+		TVS.SV.dragable = nil
+	end
+
 	TVS.SV.version = TVS.version
 end
 
-function TVS.dtvs(value)
+-- value: the message to print.
+-- category: optional saved-var key (e.g. "notifyBank") for a per-category toggle.
+--           When given, the message is suppressed if that category is disabled.
+--           "notifications" remains the master on/off switch for everything.
+function TVS.dtvs(value, category)
 	if TVS.SV.notifications == false then return end
+	if (category ~= nil) and (TVS.SV[category] == false) then return end
 	if value == nil then return end
 
 	d("|c8080ffTel Var Saver:|r " .. value)

--- a/TelvarSaver.txt
+++ b/TelvarSaver.txt
@@ -1,7 +1,7 @@
 ## Title: TelvarSaver
 ## APIVersion: 101050
 ## SavedVariables: TVSVars
-## AddOnVersion: 1.7
+## AddOnVersion: 1.8
 ## IsLibrary: False
 ## Author: Ehansonn
 ## DependsOn: LibAddonMenu-2.0>=37
@@ -21,4 +21,5 @@ TelvarSaver.lua
 settings.lua
 bindings.xml
 BankScene.lua
+AutoLeaveToggle.lua
 TelvarSaver.xml

--- a/TelvarSaver.xml
+++ b/TelvarSaver.xml
@@ -1,7 +1,7 @@
 <GuiXml>
     <Controls>
         <TopLevelControl name="TVSView" alpha="1" mouseEnabled="true" movable="true" hidden="true" clampedToScreen="true">
-            <Dimensions x="275" y="200" />
+            <Dimensions x="360" y="330" />
             <Anchor point="BOTTOM" relativeTo="GuiRoot" relativePoint="CENTER" />
             <OnMoveStop>
                 TelVarSaver.SaveLocation()
@@ -11,17 +11,12 @@
                 <Backdrop name="$(parent)BG" inherits="ZO_DefaultBackdrop" />
 
                 <Label name="$(parent)WindowTitle" font="ZoFontAnnounceMedium" text="|c8080ffTELVAR|r  Saver">
-                    <Anchor point="TOP" relativeTo="$(parent)" relativePoint="TOP" />
+                    <Anchor point="TOP" relativeTo="$(parent)" relativePoint="TOP" offsetY="8" />
                 </Label>
 
-                <Texture name="$(parent)TopDivider" textureFile="/esoui/art/miscellaneous/horizontaldivider.dds" tier="HIGH">
-                    <Dimensions x="300" y="4"/>
-                    <Anchor point="TOP" relativeTo="$(parent)" offsetY="38" />
-                </Texture>
-
                 <Button name="$(parent)ButtonCloseAddon" inherits="ZO_ButtonBehaviorClickSound">
-                    <Dimensions x="40" y="40" />
-                    <Anchor point="TOPRIGHT" relativeTo="$(parent)" relativePoint="TOPRIGHT" offsetX="15" />
+                    <Dimensions x="36" y="36" />
+                    <Anchor point="TOPRIGHT" relativeTo="$(parent)" relativePoint="TOPRIGHT" offsetX="-6" offsetY="6" />
                     <Textures normal="EsoUI/Art/Buttons/closebutton_up.dds"
                               pressed="EsoUI/Art/Buttons/closebutton_down.dds"
                               mouseOver="EsoUI/Art/Buttons/closebutton_mouseover.dds"
@@ -31,71 +26,162 @@
                     </OnClicked>
                 </Button>
 
+                <Texture name="$(parent)TopDivider" textureFile="/esoui/art/miscellaneous/horizontaldivider.dds" tier="HIGH">
+                    <Dimensions x="340" y="4"/>
+                    <Anchor point="TOP" relativeTo="$(parent)" relativePoint="TOP" offsetY="40" />
+                </Texture>
 
-                <Label name="$(parent)10kButton" font="ZoFontAnnounceMedium" text="|c8080ff10k|r">
-                    <Anchor point="TOPRIGHT" relativeTo="$(parent)" relativePoint="TOPRIGHT" offsetX="-20" offsetY="75" />
+                <!-- Totals -->
+                <Label name="$(parent)CurrentText" font="ZoFontWinH4" text="Current">
+                    <Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="24" offsetY="50" />
                 </Label>
-                <Button name="$(parent)ButtonDepo10k" inherits="ZO_ButtonBehaviorClickSound ZO_RadioButton" mouseOverBlendMode="ADD">
-                    <Dimensions x="40" y="40" />
-                    <Anchor point="TOPRIGHT" relativeTo="$(parent)" relativePoint="TOPRIGHT" offsetX="-60" offsetY="75"/>
-                    <Textures normal="EsoUI/Art/Tooltips/icon_bag.dds"
-                              pressed="EsoUI/Art/Tooltips/icon_bag.dds"
-                              mouseOver="EsoUI/Art/Tooltips/icon_bag.dds"
-                              disabled="EsoUI/Art/Tooltips/icon_bag.dds"/>
-                    <OnClicked>
-                        TelVarSaver.TelvarButton(10000)
-                    </OnClicked>
-                </Button>
-
-
-                <Label name="$(parent)1kButton" font="ZoFontAnnounceMedium" text="|c8080ff1k|r">
-                    <Anchor point="TOPRIGHT" relativeTo="$(parent)" relativePoint="TOPRIGHT" offsetX="-120" offsetY="75" />
+                <Label name="$(parent)CurrentTextValue" font="ZoFontWinH4" text="|c8080ff0|r">
+                    <Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="150" offsetY="50" />
                 </Label>
-                <Button name="$(parent)ButtonDepo1k" inherits="ZO_ButtonBehaviorClickSound ZO_RadioButton" mouseOverBlendMode="ADD">
-                    <Dimensions x="40" y="40" />
-                    <Anchor point="TOPRIGHT" relativeTo="$(parent)" relativePoint="TOPRIGHT" offsetX="-140" offsetY="75"/>
-                    <Textures normal="EsoUI/Art/Tooltips/icon_bag.dds"
-                              pressed="EsoUI/Art/Tooltips/icon_bag.dds"
-                              mouseOver="EsoUI/Art/Tooltips/icon_bag.dds"
-                              disabled="EsoUI/Art/Tooltips/icon_bag.dds"/>
-                    <OnClicked>
-                        TelVarSaver.TelvarButton(1000)
-                    </OnClicked>
-                </Button>
-
-                <Label name="$(parent)0Button" font="ZoFontAnnounceMedium" text="|c8080ff0|r">
-                    <Anchor point="TOPRIGHT" relativeTo="$(parent)" relativePoint="TOPRIGHT" offsetX="-200" offsetY="75" />
+                <Label name="$(parent)BankText" font="ZoFontWinH4" text="Banked">
+                    <Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="24" offsetY="76" />
                 </Label>
-                <Button name="$(parent)ButtonDepo0" inherits="ZO_ButtonBehaviorClickSound ZO_RadioButton" mouseOverBlendMode="ADD" >
+                <Label name="$(parent)BankTextValue" font="ZoFontWinH4" text="|c8080ff0|r">
+                    <Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="150" offsetY="76" />
+                </Label>
+
+                <Texture name="$(parent)Divider2" textureFile="/esoui/art/miscellaneous/horizontaldivider.dds" tier="HIGH">
+                    <Dimensions x="340" y="4"/>
+                    <Anchor point="TOP" relativeTo="$(parent)" relativePoint="TOP" offsetY="106" />
+                </Texture>
+
+                <!-- Preset deposit/withdraw buttons (set carried Tel Var to a fixed amount) -->
+                <Label name="$(parent)PresetHint" font="ZoFontGameSmall" text="|cCCCCCCSet carried Tel Var to:|r">
+                    <Anchor point="TOP" relativeTo="$(parent)" relativePoint="TOP" offsetY="114" />
+                </Label>
+
+                <Button name="$(parent)ButtonDepo0" inherits="ZO_ButtonBehaviorClickSound ZO_RadioButton" mouseOverBlendMode="ADD">
                     <Dimensions x="40" y="40" />
-                    <Anchor point="TOPRIGHT" relativeTo="$(parent)" relativePoint="TOPRIGHT" offsetX="-220" offsetY="75"/>
-                    <Textures normal="EsoUI/Art/Tooltips/icon_bag.dds"
-                              pressed="EsoUI/Art/Tooltips/icon_bag.dds"
-                              mouseOver="EsoUI/Art/Tooltips/icon_bag.dds"
-                              disabled="EsoUI/Art/Tooltips/icon_bag.dds"/>
+                    <Anchor point="TOP" relativeTo="$(parent)" relativePoint="TOP" offsetX="-126" offsetY="136"/>
+                    <Textures normal="EsoUI/Art/Tooltips/icon_bag.dds" pressed="EsoUI/Art/Tooltips/icon_bag.dds"
+                              mouseOver="EsoUI/Art/Tooltips/icon_bag.dds" disabled="EsoUI/Art/Tooltips/icon_bag.dds"/>
                     <OnClicked>
                         TelVarSaver.TelvarButton(0)
                     </OnClicked>
                 </Button>
-                <Label name="$(parent)CurrentText" font="ZoFontAnnounceMedium" text="Current">
-                    <Anchor point="BOTTOMLEFT" relativeTo="$(parent)" relativePoint="BOTTOMLEFT" offsetX="0" offsetY="0" />
-                </Label>
-                <Label name="$(parent)BankText" font="ZoFontAnnounceMedium" text="Banked">
-                    <Anchor point="BOTTOMLEFT" relativeTo="$(parent)" relativePoint="BOTTOMLEFT" offsetX="0" offsetY="-30" />
+                <Label name="$(parent)0Button" font="ZoFontGameBold" text="|c8080ff0|r">
+                    <Anchor point="TOP" relativeTo="$(parent)ButtonDepo0" relativePoint="BOTTOM" offsetY="0" />
                 </Label>
 
-                <Label name="$(parent)CurrentTextValue" font="ZoFontAnnounceMedium" text="|c8080ff0|r">
-                    <Anchor point="BOTTOMLEFT" relativeTo="$(parent)" relativePoint="BOTTOMLEFT" offsetX="78" offsetY="0" />
-                </Label>
-                <Label name="$(parent)BankTextValue" font="ZoFontAnnounceMedium" text="|c8080ff0|r">
-                    <Anchor point="BOTTOMLEFT" relativeTo="$(parent)" relativePoint="BOTTOMLEFT" offsetX="78" offsetY="-30" />
+                <Button name="$(parent)ButtonDepo100" inherits="ZO_ButtonBehaviorClickSound ZO_RadioButton" mouseOverBlendMode="ADD">
+                    <Dimensions x="40" y="40" />
+                    <Anchor point="TOP" relativeTo="$(parent)" relativePoint="TOP" offsetX="-42" offsetY="136"/>
+                    <Textures normal="EsoUI/Art/Tooltips/icon_bag.dds" pressed="EsoUI/Art/Tooltips/icon_bag.dds"
+                              mouseOver="EsoUI/Art/Tooltips/icon_bag.dds" disabled="EsoUI/Art/Tooltips/icon_bag.dds"/>
+                    <OnClicked>
+                        TelVarSaver.TelvarButton(100)
+                    </OnClicked>
+                </Button>
+                <Label name="$(parent)100Button" font="ZoFontGameBold" text="|c8080ff100|r">
+                    <Anchor point="TOP" relativeTo="$(parent)ButtonDepo100" relativePoint="BOTTOM" offsetY="0" />
                 </Label>
 
+                <Button name="$(parent)ButtonDepo1k" inherits="ZO_ButtonBehaviorClickSound ZO_RadioButton" mouseOverBlendMode="ADD">
+                    <Dimensions x="40" y="40" />
+                    <Anchor point="TOP" relativeTo="$(parent)" relativePoint="TOP" offsetX="42" offsetY="136"/>
+                    <Textures normal="EsoUI/Art/Tooltips/icon_bag.dds" pressed="EsoUI/Art/Tooltips/icon_bag.dds"
+                              mouseOver="EsoUI/Art/Tooltips/icon_bag.dds" disabled="EsoUI/Art/Tooltips/icon_bag.dds"/>
+                    <OnClicked>
+                        TelVarSaver.TelvarButton(1000)
+                    </OnClicked>
+                </Button>
+                <Label name="$(parent)1kButton" font="ZoFontGameBold" text="|c8080ff1k|r">
+                    <Anchor point="TOP" relativeTo="$(parent)ButtonDepo1k" relativePoint="BOTTOM" offsetY="0" />
+                </Label>
+
+                <Button name="$(parent)ButtonDepo10k" inherits="ZO_ButtonBehaviorClickSound ZO_RadioButton" mouseOverBlendMode="ADD">
+                    <Dimensions x="40" y="40" />
+                    <Anchor point="TOP" relativeTo="$(parent)" relativePoint="TOP" offsetX="126" offsetY="136"/>
+                    <Textures normal="EsoUI/Art/Tooltips/icon_bag.dds" pressed="EsoUI/Art/Tooltips/icon_bag.dds"
+                              mouseOver="EsoUI/Art/Tooltips/icon_bag.dds" disabled="EsoUI/Art/Tooltips/icon_bag.dds"/>
+                    <OnClicked>
+                        TelVarSaver.TelvarButton(10000)
+                    </OnClicked>
+                </Button>
+                <Label name="$(parent)10kButton" font="ZoFontGameBold" text="|c8080ff10k|r">
+                    <Anchor point="TOP" relativeTo="$(parent)ButtonDepo10k" relativePoint="BOTTOM" offsetY="0" />
+                </Label>
+
+                <!-- In-window auto deposit/withdraw controls (mirrors the addon menu settings) -->
+                <Texture name="$(parent)Divider3" textureFile="/esoui/art/miscellaneous/horizontaldivider.dds" tier="HIGH">
+                    <Dimensions x="340" y="4"/>
+                    <Anchor point="TOP" relativeTo="$(parent)" relativePoint="TOP" offsetY="202" />
+                </Texture>
+
+                <Label name="$(parent)AutoManageHeader" font="ZoFontWinH4" text="|c8080ffAuto Manage|r" horizontalAlignment="CENTER">
+                    <Anchor point="TOP" relativeTo="$(parent)" relativePoint="TOP" offsetY="210" />
+                </Label>
+
+                <Button name="$(parent)AutoDepoToggle" inherits="ZO_CheckButton">
+                    <Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="24" offsetY="240" />
+                </Button>
+
+                <Button name="$(parent)AutoWithdrawToggle" inherits="ZO_CheckButton">
+                    <Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="24" offsetY="266" />
+                </Button>
+
+                <Label name="$(parent)DesiredLabel" font="ZoFontGame" text="Desired carried:">
+                    <Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="24" offsetY="294" />
+                </Label>
+                <Backdrop name="$(parent)DesiredBackdrop" inherits="ZO_DefaultBackdrop">
+                    <Dimensions x="110" y="28" />
+                    <Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="160" offsetY="290" />
+                    <Controls>
+                        <EditBox name="$(parent)Edit" inherits="ZO_DefaultEdit">
+                            <Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="8" offsetY="2" />
+                            <Anchor point="BOTTOMRIGHT" relativeTo="$(parent)" relativePoint="BOTTOMRIGHT" offsetX="-8" offsetY="-2" />
+                            <OnEnter>
+                                self:LoseFocus()
+                            </OnEnter>
+                            <OnFocusLost>
+                                TelVarSaver.CommitDesiredEdit()
+                            </OnFocusLost>
+                        </EditBox>
+                    </Controls>
+                </Backdrop>
 
             </Controls>
 
         </TopLevelControl>
 
+        <!-- On-screen toggle for "Auto leave when telvar limit reached".
+             Defaults to the top right of the screen, draggable, position saved. -->
+        <TopLevelControl name="TVSAutoLeaveToggle" alpha="1" mouseEnabled="true" movable="true" hidden="true" clampedToScreen="true">
+            <Dimensions x="62" y="64" />
+            <Anchor point="TOPRIGHT" relativeTo="GuiRoot" relativePoint="TOPRIGHT" offsetX="-150" offsetY="150" />
+            <OnMoveStart>
+                TelVarSaver.OnAutoLeaveToggleMoveStart()
+            </OnMoveStart>
+            <OnMoveStop>
+                TelVarSaver.OnAutoLeaveToggleMoveStop()
+            </OnMoveStop>
+            <OnMouseUp>
+                TelVarSaver.OnAutoLeaveToggleMouseUp(button, upInside)
+            </OnMouseUp>
+            <OnMouseEnter>
+                TelVarSaver.OnAutoLeaveToggleEnter()
+            </OnMouseEnter>
+            <OnMouseExit>
+                TelVarSaver.OnAutoLeaveToggleExit()
+            </OnMouseExit>
+            <Controls>
+                <Backdrop name="$(parent)BG" inherits="ZO_DefaultBackdrop" />
+
+                <Texture name="$(parent)Icon" textureFile="EsoUI/Art/currency/currency_telvar_32.dds">
+                    <Dimensions x="36" y="36" />
+                    <Anchor point="TOP" relativeTo="$(parent)" relativePoint="TOP" offsetY="6" />
+                </Texture>
+
+                <Label name="$(parent)Status" font="ZoFontGameBold" text="OFF" horizontalAlignment="CENTER" verticalAlignment="CENTER">
+                    <Anchor point="BOTTOM" relativeTo="$(parent)" relativePoint="BOTTOM" offsetY="-4" />
+                </Label>
+            </Controls>
+        </TopLevelControl>
 
     </Controls>
 </GuiXml>

--- a/bindings.xml
+++ b/bindings.xml
@@ -4,6 +4,9 @@
             <Action name="QUEUETVSCAMP">
                 <Down>TelVarSaver.queueCamp()</Down>
             </Action>
+            <Action name="TVSTOGGLEAUTOLEAVE">
+                <Down>TelVarSaver.ToggleAutoLeave()</Down>
+            </Action>
         </Category>
     </Layer>
 </Bindings>

--- a/settings.lua
+++ b/settings.lua
@@ -16,13 +16,47 @@ function TVS.CreateSettingsMenu()
 	local options = {}
 
 	table.insert(options, {
-		type = "checkbox",
+		type = "header",
 		name = "Chat Notifications",
-		textType = TEXT_TYPE_NUMERIC_UNSIGNED_INT,
-		tooltip = "",
+	})
+
+	table.insert(options, {
+		type = "checkbox",
+		name = "Chat notifications (master)",
+		tooltip = "Master switch for all Tel Var Saver chat messages. When off, nothing below is printed.",
 		default = TVS.defaults.notifications,
 		getFunc = function() return TVS.SV.notifications end,
 		setFunc = function(value) TVS.SV.notifications = value end,
+	})
+
+	table.insert(options, {
+		type = "checkbox",
+		name = "Bank notifications",
+		tooltip = "Deposits and withdrawals: auto/manual deposit and withdraw messages, and bank-related warnings.",
+		default = TVS.defaults.notifyBank,
+		disabled = function() return TVS.SV.notifications == false end,
+		getFunc = function() return TVS.SV.notifyBank end,
+		setFunc = function(value) TVS.SV.notifyBank = value end,
+	})
+
+	table.insert(options, {
+		type = "checkbox",
+		name = "Auto-leave notifications",
+		tooltip = "Messages when you toggle 'Auto leave when telvar limit reached' on or off.",
+		default = TVS.defaults.notifyAutoLeave,
+		disabled = function() return TVS.SV.notifications == false end,
+		getFunc = function() return TVS.SV.notifyAutoLeave end,
+		setFunc = function(value) TVS.SV.notifyAutoLeave = value end,
+	})
+
+	table.insert(options, {
+		type = "checkbox",
+		name = "Queue / campaign notifications",
+		tooltip = "Messages about queuing, entering campaigns, queue blocks, and kicking offline group members.",
+		default = TVS.defaults.notifyQueue,
+		disabled = function() return TVS.SV.notifications == false end,
+		getFunc = function() return TVS.SV.notifyQueue end,
+		setFunc = function(value) TVS.SV.notifyQueue = value end,
 	})
 
 	table.insert(options, {
@@ -63,7 +97,7 @@ function TVS.CreateSettingsMenu()
 		type = "checkbox",
 		name = "Skip bank dialog in IC",
 		textType = TEXT_TYPE_NUMERIC_UNSIGNED_INT,
-		tooltip = "Will skip the bank dialog if youre in IC.",
+		tooltip = "Will skip the bank dialog if you're in IC.",
 		default = TVS.defaults.SkipBankDialog,
 		getFunc = function() return TVS.SV.SkipBankDialog end,
 		setFunc = function(value) TVS.SV.SkipBankDialog = value end,
@@ -81,7 +115,10 @@ function TVS.CreateSettingsMenu()
 		tooltip = "If your current carried telvar exceeds your desired amount, deposit the excess",
 		default = TVS.defaults.AutoDepoTelvar,
 		getFunc = function() return TVS.SV.AutoDepoTelvar end,
-		setFunc = function(value) TVS.SV.AutoDepoTelvar = value end,
+		setFunc = function(value)
+			TVS.SV.AutoDepoTelvar = value
+			TVS.UpdateBankControls()
+		end,
 	})
 
 	table.insert(options, {
@@ -91,7 +128,10 @@ function TVS.CreateSettingsMenu()
 		tooltip = "If your current carried telvar is below your desired amount, withdraw the amount to reach it",
 		default = TVS.defaults.AutoWithdrawTelvar,
 		getFunc = function() return TVS.SV.AutoWithdrawTelvar end,
-		setFunc = function(value) TVS.SV.AutoWithdrawTelvar = value end,
+		setFunc = function(value)
+			TVS.SV.AutoWithdrawTelvar = value
+			TVS.UpdateBankControls()
+		end,
 	})
 
 	table.insert(options, {
@@ -110,6 +150,7 @@ function TVS.CreateSettingsMenu()
 				d("Invalid amount. Must be between 0 and 10000")
 			end
 			TVS.SV.DesiredTelvarAmount = amount
+			TVS.UpdateBankControls()
 		end,
 	})
 
@@ -126,21 +167,66 @@ function TVS.CreateSettingsMenu()
 		default = TVS.defaults.BankScene,
 		getFunc = function() return TVS.SV.BankScene end,
 		setFunc = function(value)
-			if value == false then TVS.CloseBank() end
+			if value == false then TVS.HideUi() end
 			TVS.SV.BankScene = value
 		end,
 	})
 
 	table.insert(options, {
 		type = "checkbox",
-		name = "Dragable",
+		name = "Draggable",
 		textType = TEXT_TYPE_NUMERIC_UNSIGNED_INT,
 		tooltip = "",
-		default = TVS.defaults.dragable,
-		getFunc = function() return TVS.SV.dragable end,
+		default = TVS.defaults.draggable,
+		getFunc = function() return TVS.SV.draggable end,
 		setFunc = function(value)
-			TVS.SV.dragable = value
+			TVS.SV.draggable = value
 			TVS.UpdateAnchors()
+		end,
+	})
+
+	table.insert(options, {
+		type = "header",
+		name = "Auto-Leave Widget",
+	})
+
+	table.insert(options, {
+		type = "description",
+		text = "Toggles 'Auto leave when telvar limit reached' on/off without opening this menu. It shows your telvar limit in green when on, red when off.",
+	})
+
+	
+	table.insert(options, {
+		type = "checkbox",
+		name = "Show button",
+		tooltip = "Shows a small draggable icon that toggles 'Auto leave when telvar limit reached' on/off without opening this menu.",
+		default = TVS.defaults.AutoLeaveToggleShow,
+		getFunc = function() return TVS.SV.AutoLeaveToggleShow end,
+		setFunc = function(value)
+			TVS.SV.AutoLeaveToggleShow = value
+			TVS.RefreshAutoLeaveToggleVisibility()
+		end,
+	})
+
+	table.insert(options, {
+		type = "checkbox",
+		name = "Draggable",
+		tooltip = "Determines if the on-screen Auto-Leave toggle button can be dragged.",
+		default = TVS.defaults.AutoLeaveToggleDragable,
+		getFunc = function() return TVS.SV.AutoLeaveToggleDragable end,
+		setFunc = function(value)
+			TVS.SV.AutoLeaveToggleDragable = value
+			TVS.UpdateAutoLeaveTogglePosition()
+		end,
+	})
+
+	table.insert(options, {
+		type = "button",
+		name = "Reset Auto-Leave toggle position",
+		func = function()
+			TVS.SV.AutoLeaveToggleX = TVS.defaults.AutoLeaveToggleX
+			TVS.SV.AutoLeaveToggleY = TVS.defaults.AutoLeaveToggleY
+			TVS.UpdateAutoLeaveTogglePosition()
 		end,
 	})
 
@@ -260,10 +346,13 @@ function TVS.CreateSettingsMenu()
 		type = "checkbox",
 		name = "Auto leave when telvar limit reached",
 		textType = TEXT_TYPE_NUMERIC_UNSIGNED_INT,
-		tooltip = "Only triggers if you gain telvar, and the limit exceeds the set amount below. Wont trigger if you withdraw from your bank or something so be careful",
+		tooltip = "Only triggers if you gain telvar, and the limit exceeds the set amount below. Won't trigger if you withdraw from your bank or something so be careful",
 		default = TVS.defaults.AutoQueueOut,
 		getFunc = function() return TVS.SV.AutoQueueOut end,
-		setFunc = function(value) TVS.SV.AutoQueueOut = value end,
+		setFunc = function(value)
+			TVS.SV.AutoQueueOut = value
+			TVS.UpdateAutoLeaveToggleVisual()
+		end,
 	})
 
 	table.insert(options, {
@@ -279,6 +368,7 @@ function TVS.CreateSettingsMenu()
 			if value <= 0 then value = 1 end
 			if value > GetTelVarQueueThreshold() then value = GetTelVarQueueThreshold() end
 			TVS.SV.TelvarCap = value
+			TVS.UpdateAutoLeaveToggleVisual()
 		end,
 	})
 
@@ -328,7 +418,7 @@ function TVS.CreateSettingsMenu()
 		type = "checkbox",
 		name = "Group queue ",
 		textType = TEXT_TYPE_NUMERIC_UNSIGNED_INT,
-		tooltip = "Determines if you group queue if youre the group leader when you hit the keybind or reach your cap",
+		tooltip = "Determines if you group queue if you're the group leader when you hit the keybind or reach your cap",
 		default = TVS.defaults.GroupQueue,
 		getFunc = function() return TVS.SV.GroupQueue end,
 		setFunc = function(value) TVS.SV.GroupQueue = value end,
@@ -336,7 +426,7 @@ function TVS.CreateSettingsMenu()
 
 	table.insert(options, {
 		type = "description",
-		text = "Check your controls for the keybind, its unbound by default",
+		text = "Check your controls for the keybind, it's unbound by default",
 	})
 
 	table.insert(options, {
@@ -378,7 +468,10 @@ function TVS.CreateSettingsMenu()
 					TVS.SV.AutoLootTelvar = TVS.defaults.AutoLootTelvar
 					TVS.SV.AutoLootKeyFrags = TVS.defaults.AutoLootKeyFrags
 					TVS.SV.notifications = TVS.defaults.notifications
-					TVS.SV.dragable = TVS.defaults.dragable
+					TVS.SV.notifyBank = TVS.defaults.notifyBank
+					TVS.SV.notifyAutoLeave = TVS.defaults.notifyAutoLeave
+					TVS.SV.notifyQueue = TVS.defaults.notifyQueue
+					TVS.SV.draggable = TVS.defaults.draggable
 					TVS.SV.locationx = TVS.defaults.locationx
 					TVS.SV.locationy = TVS.defaults.locationy
 					TVS.SV.BankScene = TVS.defaults.BankScene
@@ -393,6 +486,10 @@ function TVS.CreateSettingsMenu()
 					TVS.SV.DisableKeybindInPVE = TVS.defaults.DisableKeybindInPVE
 					TVS.SV.SmartQueuePicker = TVS.defaults.SmartQueuePicker
 					TVS.SV.AllowCyrodiilCampaigns = TVS.defaults.AllowCyrodiilCampaigns
+					TVS.SV.AutoLeaveToggleShow = TVS.defaults.AutoLeaveToggleShow
+					TVS.SV.AutoLeaveToggleDragable = TVS.defaults.AutoLeaveToggleDragable
+					TVS.SV.AutoLeaveToggleX = TVS.defaults.AutoLeaveToggleX
+					TVS.SV.AutoLeaveToggleY = TVS.defaults.AutoLeaveToggleY
 					ReloadUI()
 				end, 100)
 			end)
@@ -400,6 +497,6 @@ function TVS.CreateSettingsMenu()
 	})
 
 	-- Registering Panel and Options
-	local controlPanel = LAM:RegisterAddonPanel(panelName, panelData)
+	TVS.settingsPanel = LAM:RegisterAddonPanel(panelName, panelData)
 	LAM:RegisterOptionControls(panelName, options)
 end


### PR DESCRIPTION
## Summary
Adds an on-screen auto-leave toggle, overhauls the bank window, splits chat notifications into categories, and fixes a few latent bugs.

### On-screen Auto-Leave widget (`AutoLeaveToggle.lua`)
- Draggable icon (defaults to top-right) that toggles **Auto leave when telvar limit reached** without opening settings.
- Shows the telvar limit, colored **green** (on) / **red** (off), with a matching green/red outline, and **yellow** when you're already carrying more than the queue threshold.
- Only visible in Imperial City, and **hides in menus/inventory/map** via a HUD scene fragment (same approach as Combat Metrics) — no per-event/per-frame work.
- New **bindable keybind** to toggle it, and **right-click opens settings**.

### Bank window
- New **100** preset button.
- Reorganized top-down with section dividers (Totals / Presets / Auto Manage).
- In-window **Auto Manage** controls — native checkboxes for auto deposit/withdraw and a desired-amount editbox — mirroring the addon menu and kept in sync both ways.
- **Comma-formatted** Current/Banked totals.

### Notifications
- Chat notifications split into a dedicated settings section: a **master switch** plus per-category toggles (**bank**, **auto-leave**, **queue/campaign**). `dtvs` is now category-aware.

### Fixes
- `CloseBank()` → `HideUi()` (it called a function that didn't exist).
- Pinned `SVVersion` so updates no longer wipe saved settings; migrate the renamed `dragable` → `draggable` key.
- Removed dead `currentTelvarOnChar - currentTelvarOnChar` button-dimming logic.
- Spelling/typo pass across user-facing strings.

## Testing notes
Not yet verified in-game — XML layout offsets are calibrated estimates and may need minor nudging. Requires `/reloadui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an on-screen Auto Leave toggle for Imperial City telvar management, with drag-and-drop positioning and a reset option.
  * Expanded the bank interface with more preset amount buttons and a “Desired carried” field for auto-manage settings.
  * Added separate notification controls, including a master toggle and per-action notification options.

* **Bug Fixes**
  * Improved telvar count formatting and corrected bank button dimming behavior.
  * Fixed draggable setting behavior and updated reset actions to restore new defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->